### PR TITLE
채팅방 기능 구현

### DIFF
--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
@@ -6,6 +6,7 @@ import com.freepath.devpath.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,4 +37,14 @@ public class ChattingRoomCommandController {
                 chattingRoomCommandService.createGroupChattingRoom(userDetails.getUsername(), boardId);
         return ResponseEntity.ok(ApiResponse.success(chattingRoomCommandResponse));
     }
+
+    @PutMapping("/chatting/list/{chattingRoomId}")
+    public ResponseEntity<ApiResponse<Void>> quitChattingRoom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable int chattingRoomId
+    ){
+        chattingRoomCommandService.quitChattingRoom(userDetails.getUsername(),chattingRoomId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
 }

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
@@ -1,0 +1,39 @@
+package com.freepath.devpath.chattingroom.command.application.controller;
+
+import com.freepath.devpath.chattingroom.command.application.dto.response.ChattingRoomCommandResponse;
+import com.freepath.devpath.chattingroom.command.application.service.ChattingRoomCommandService;
+import com.freepath.devpath.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class ChattingRoomCommandController {
+    private final ChattingRoomCommandService chattingRoomCommandService;
+
+    @PostMapping("/chatting/create/{userId}")
+    public ResponseEntity<ApiResponse<ChattingRoomCommandResponse>> createChattingRoom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable int userId
+    ){
+        ChattingRoomCommandResponse chattingRoomCommandResponse =
+                chattingRoomCommandService.createChattingRoom(userDetails.getUsername(), userId);
+        return ResponseEntity.ok(ApiResponse.success(chattingRoomCommandResponse));
+    }
+
+    @PostMapping("/chatting/create/group/{boardId}")
+    public ResponseEntity<ApiResponse<ChattingRoomCommandResponse>> createGroupChattingRoom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable int boardId
+    ){
+        ChattingRoomCommandResponse chattingRoomCommandResponse =
+                chattingRoomCommandService.createGroupChattingRoom(userDetails.getUsername(), boardId);
+        return ResponseEntity.ok(ApiResponse.success(chattingRoomCommandResponse));
+    }
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/controller/ChattingRoomCommandController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -44,6 +45,15 @@ public class ChattingRoomCommandController {
             @PathVariable int chattingRoomId
     ){
         chattingRoomCommandService.quitChattingRoom(userDetails.getUsername(),chattingRoomId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/chatting/list/{chattingRoomId}")
+    public ResponseEntity<ApiResponse<Void>> deleteChattingRoom(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable int chattingRoomId
+    ){
+        chattingRoomCommandService.deleteChattingRoom(userDetails.getUsername(),chattingRoomId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/dto/request/ChattingRoomCreateRequest.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/dto/request/ChattingRoomCreateRequest.java
@@ -1,0 +1,7 @@
+package com.freepath.devpath.chattingroom.command.application.dto.request;
+
+public class ChattingRoomCreateRequest {
+    private int boardId;
+    private String chattingRoomTitle;
+    private int userCount;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/dto/response/ChattingRoomCommandResponse.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/dto/response/ChattingRoomCommandResponse.java
@@ -1,0 +1,10 @@
+package com.freepath.devpath.chattingroom.command.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChattingRoomCommandResponse {
+    private int chattingRoomId;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
@@ -78,4 +78,11 @@ public class ChattingRoomCommandService {
         chattingJoin.setChattingJoinStatus('N');
 
     }
+
+    @Transactional
+    public void deleteChattingRoom(String username, int chattingRoomId) {
+        int userId = Integer.parseInt(username);
+        chattingRoomRepository.deleteById(chattingRoomId);
+        chattingJoinRepository.deleteByChattingRoomId(chattingRoomId);
+    }
 }

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
@@ -1,0 +1,68 @@
+package com.freepath.devpath.chattingroom.command.application.service;
+
+import com.freepath.devpath.chattingroom.command.application.dto.response.ChattingRoomCommandResponse;
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoin;
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoinId;
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingRole;
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingRoom;
+import com.freepath.devpath.chattingroom.command.domain.repository.ChattingJoinRepository;
+import com.freepath.devpath.chattingroom.command.domain.repository.ChattingRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChattingRoomCommandService {
+    private final ChattingJoinRepository chattingJoinRepository;
+    private final ChattingRoomRepository chattingRoomRepository;
+
+    @Transactional
+    public ChattingRoomCommandResponse createChattingRoom(
+            String username,
+            int inviteeId
+    ) {
+        ChattingRoom chattingRoom = ChattingRoom.builder()
+                .userCount(2)
+                .chattingRoomTitle("채팅방")
+                .boardId(null)
+                .build();
+        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoom);
+        int chattingRoomId = savedChattingRoom.getChattingRoomId();
+        int creatorId = Integer.parseInt(username);
+        ChattingJoin chattingJoin1 = chattingJoinBuild(creatorId, chattingRoomId,ChattingRole.ONE);
+        ChattingJoin chattingJoin2 = chattingJoinBuild(inviteeId, chattingRoomId,ChattingRole.ONE);
+
+        chattingJoinRepository.save(chattingJoin1);
+        chattingJoinRepository.save(chattingJoin2);
+        return new ChattingRoomCommandResponse(chattingRoomId);
+    }
+
+
+    private ChattingJoin chattingJoinBuild(int userId, int chattingRoomId, ChattingRole chattingRole) {
+        return ChattingJoin.builder()
+                        .id(new ChattingJoinId(chattingRoomId, userId))
+                .chattingRole(chattingRole)
+                .chattingJoinStatus('Y')
+                                .build();
+
+    }
+
+    public ChattingRoomCommandResponse createGroupChattingRoom(
+            String username, int boardId
+    ) {
+        ChattingRoom chattingRoom = ChattingRoom.builder()
+                .userCount(1)
+                .chattingRoomTitle("채팅방")
+                .boardId(boardId)
+                .build();
+        ChattingRoom savedChattingRoom = chattingRoomRepository.save(chattingRoom);
+        int chattingRoomId = savedChattingRoom.getChattingRoomId();
+        int creatorId = Integer.parseInt(username);
+        ChattingJoin chattingJoin1 = chattingJoinBuild(creatorId, chattingRoomId,ChattingRole.OWNER);
+
+
+        chattingJoinRepository.save(chattingJoin1);
+        return new ChattingRoomCommandResponse(chattingRoomId);
+    }
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/application/service/ChattingRoomCommandService.java
@@ -48,6 +48,7 @@ public class ChattingRoomCommandService {
 
     }
 
+    @Transactional
     public ChattingRoomCommandResponse createGroupChattingRoom(
             String username, int boardId
     ) {
@@ -64,5 +65,17 @@ public class ChattingRoomCommandService {
 
         chattingJoinRepository.save(chattingJoin1);
         return new ChattingRoomCommandResponse(chattingRoomId);
+    }
+
+    @Transactional
+    public void quitChattingRoom(String username, int chattingRoomId) {
+        int userId = Integer.parseInt(username);
+        ChattingRoom chattingRoom = chattingRoomRepository.findById(chattingRoomId)
+                .orElseThrow(() -> new RuntimeException("해당 채팅방은 없습니다."));
+        chattingRoom.setUserCount(chattingRoom.getUserCount()-1);
+        ChattingJoin chattingJoin= chattingJoinRepository.findById(new ChattingJoinId(chattingRoomId,userId))
+                .orElseThrow(() -> new RuntimeException("채팅방에 참여하고 있지 않습니다."));
+        chattingJoin.setChattingJoinStatus('N');
+
     }
 }

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingJoin.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingJoin.java
@@ -1,0 +1,22 @@
+package com.freepath.devpath.chattingroom.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name="chatting_join")
+public class ChattingJoin {
+
+    @EmbeddedId
+    private ChattingJoinId id;
+
+    @Enumerated(EnumType.STRING)
+    private ChattingRole chattingRole;
+
+    private char chattingJoinStatus;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingJoinId.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingJoinId.java
@@ -1,0 +1,36 @@
+package com.freepath.devpath.chattingroom.command.domain.aggregate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChattingJoinId implements Serializable {
+
+    @Column(name = "chatting_room_id")
+    private Integer chattingRoomId;
+
+    @Column(name = "user_id")
+    private Integer userId;
+
+    // equals & hashCode
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChattingJoinId)) return false;
+        ChattingJoinId that = (ChattingJoinId) o;
+        return Objects.equals(chattingRoomId, that.chattingRoomId) &&
+                Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chattingRoomId, userId);
+    }
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingRole.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingRole.java
@@ -1,0 +1,5 @@
+package com.freepath.devpath.chattingroom.command.domain.aggregate;
+
+public enum ChattingRole {
+    ONE,OWNER, MEMBER
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingRoom.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/aggregate/ChattingRoom.java
@@ -1,0 +1,20 @@
+package com.freepath.devpath.chattingroom.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name="chatting_room")
+public class ChattingRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int chattingRoomId;
+    private Integer boardId;
+    private String chattingRoomTitle;
+    private int userCount;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingJoinRepository.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingJoinRepository.java
@@ -1,0 +1,8 @@
+package com.freepath.devpath.chattingroom.command.domain.repository;
+
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoin;
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoinId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChattingJoinRepository extends JpaRepository<ChattingJoin, ChattingJoinId> {
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingJoinRepository.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingJoinRepository.java
@@ -2,7 +2,13 @@ package com.freepath.devpath.chattingroom.command.domain.repository;
 
 import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoin;
 import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingJoinId;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChattingJoinRepository extends JpaRepository<ChattingJoin, ChattingJoinId> {
+    @Modifying
+    @Query("DELETE FROM ChattingJoin cj WHERE cj.id.chattingRoomId = :chattingRoomId")
+    void deleteByChattingRoomId(@Param("chattingRoomId") int chattingRoomId);
 }

--- a/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingRoomRepository.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/command/domain/repository/ChattingRoomRepository.java
@@ -1,0 +1,8 @@
+package com.freepath.devpath.chattingroom.command.domain.repository;
+
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Integer> {
+
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/query/controller/ChattingRoomQueryController.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/controller/ChattingRoomQueryController.java
@@ -8,7 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/freepath/devpath/chattingroom/query/controller/ChattingRoomQueryController.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/controller/ChattingRoomQueryController.java
@@ -1,0 +1,25 @@
+package com.freepath.devpath.chattingroom.query.controller;
+
+import com.freepath.devpath.chattingroom.query.dto.ChattingRoomResponse;
+import com.freepath.devpath.chattingroom.query.service.ChattingRoomQueryService;
+import com.freepath.devpath.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChattingRoomQueryController {
+    private final ChattingRoomQueryService chattingRoomQueryService;
+    @GetMapping("/chatting/list")
+    public ResponseEntity<ApiResponse<ChattingRoomResponse>> getChattingRooms(
+            @AuthenticationPrincipal UserDetails userDetails
+    ){
+        ChattingRoomResponse response = chattingRoomQueryService.getChattingRooms(userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomDTO.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomDTO.java
@@ -1,0 +1,12 @@
+package com.freepath.devpath.chattingroom.query.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChattingRoomDTO {
+    private int chattingRoomId;
+    private String chattingRoomTitle;
+    private int userCount;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
@@ -1,0 +1,13 @@
+package com.freepath.devpath.chattingroom.query.dto;
+
+import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChattingRoomResponse {
+    private final List<ChattingRoom> chattingRooms;
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Getter
 @Builder
 public class ChattingRoomResponse {
-    private final List<ChattingRoom> chattingRooms;
+    private final List<ChattingRoomDTO> chattingRooms;
 }

--- a/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/dto/ChattingRoomResponse.java
@@ -1,6 +1,5 @@
 package com.freepath.devpath.chattingroom.query.dto;
 
-import com.freepath.devpath.chattingroom.command.domain.aggregate.ChattingRoom;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/freepath/devpath/chattingroom/query/mapper/ChattingRoomMapper.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/mapper/ChattingRoomMapper.java
@@ -1,0 +1,12 @@
+package com.freepath.devpath.chattingroom.query.mapper;
+
+import com.freepath.devpath.chattingroom.query.dto.ChattingRoomDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ChattingRoomMapper {
+    List<ChattingRoomDTO> selectChattingRooms(int userId);
+
+}

--- a/src/main/java/com/freepath/devpath/chattingroom/query/service/ChattingRoomQueryService.java
+++ b/src/main/java/com/freepath/devpath/chattingroom/query/service/ChattingRoomQueryService.java
@@ -1,0 +1,23 @@
+package com.freepath.devpath.chattingroom.query.service;
+
+import com.freepath.devpath.chattingroom.query.dto.ChattingRoomDTO;
+import com.freepath.devpath.chattingroom.query.dto.ChattingRoomResponse;
+import com.freepath.devpath.chattingroom.query.mapper.ChattingRoomMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChattingRoomQueryService {
+    private final ChattingRoomMapper chattingRoomMapper;
+
+    public ChattingRoomResponse getChattingRooms(String username) {
+        int userId = Integer.parseInt(username);
+        List<ChattingRoomDTO> chattingRooms = chattingRoomMapper.selectChattingRooms(userId);
+        return ChattingRoomResponse.builder()
+                .chattingRooms(chattingRooms)
+                .build();
+    }
+}

--- a/src/main/resources/mappers/chattingroom/chattingRoomMapper.xml
+++ b/src/main/resources/mappers/chattingroom/chattingRoomMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.freepath.devpath.chattingroom.query.mapper.ChattingRoomMapper">
+    <select id="selectChattingRooms" resultType="ChattingRoomDTO">
+        SELECT
+            cr.chatting_room_id,
+            cr.chatting_room_title,
+            cr.user_count
+        FROM
+            CHATTING_JOIN cj
+        JOIN
+            CHATTING_ROOM cr ON cj.chatting_room_id = cr.chatting_room_id
+        WHERE
+            cj.user_id = #{userId}
+            AND cj.chatting_join_status = 'Y';
+    </select>
+</mapper>

--- a/src/main/resources/mappers/com/devpath/chattingroom/query/mapper/chattingRoomMapper.xml
+++ b/src/main/resources/mappers/com/devpath/chattingroom/query/mapper/chattingRoomMapper.xml
@@ -3,7 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.freepath.devpath.chattingroom.query.mapper.ChattingRoomMapper">
-    <select id="selectChattingRooms" resultType="ChattingRoomDTO">
+    <select id="selectChattingRooms" resultType="com.freepath.devpath.chattingroom.query.dto.ChattingRoomDTO">
         SELECT
             cr.chatting_room_id,
             cr.chatting_room_title,


### PR DESCRIPTION
Closes #12 

## 🔥 작업 내용  
- [ ] 채팅방 목록 조회 구현
- [ ] 채팅방 생성 기능 구현
- [ ] 채팅방 나가기 기능 구현
- [ ] 채팅방 삭제 기능 구현

## ✅ 체크 리스트  
- [ ] 채팅방 목록 조회시 채팅방id, 채팅방 제목, 유저수 반환
- [ ] 일대일채팅 생성과 그룹채팅 생성 분리
- [ ] 채팅방 나가기 실행 시 userStatus를 'N'으로 변경
- [ ] 채팅방 삭 요청시 채팅방과 채팅 참여 hard delete

## ✨ 관련 이슈
- #12 
