### PR TITLE
feat: 회원의 비밀번호 재설정 기능 구현

### DIFF
--- a/src/main/java/com/freepath/devpath/common/config/SecurityConfig.java
+++ b/src/main/java/com/freepath/devpath/common/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         auth -> auth.requestMatchers(HttpMethod.POST,
                                         "/user/signup", "/user/login", "/user/refresh","/user/signup/temp","/user/email/check",
-                                        "/user/find-id", "/user/verify-email").permitAll()
+                                        "/user/find-id", "/user/verify-email", "/user/update-password").permitAll()
                                 .requestMatchers("/admin/**").hasAuthority("ADMIN")
                                 .requestMatchers(HttpMethod.PUT, "/user/info").authenticated()
                                 .requestMatchers(HttpMethod.DELETE, "/user").authenticated()

--- a/src/main/java/com/freepath/devpath/common/exception/ErrorCode.java
+++ b/src/main/java/com/freepath/devpath/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     UNAUTHORIZED_EMAIL("10003", "이메일 인증이 완료되지 않았습니다.", HttpStatus.UNAUTHORIZED),
     EMAIL_ALREADY_EXISTS("10004", "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
     SAME_AS_OLD_PASSWORD("10005", "이전 비밀번호와 같은 비밀번호는 사용할 수 없습니다.", HttpStatus.CONFLICT),
+    LOGIN_ID_ALREADY_EXISTS("10006", "이미 사용중인 ID 입니다.", HttpStatus.CONFLICT),
 
     // 게시판 관련 오류
     POST_NOT_FOUND("20001", "해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/freepath/devpath/common/exception/ErrorCode.java
+++ b/src/main/java/com/freepath/devpath/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCHED("10002", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     UNAUTHORIZED_EMAIL("10003", "이메일 인증이 완료되지 않았습니다.", HttpStatus.UNAUTHORIZED),
     EMAIL_ALREADY_EXISTS("10004", "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
+    SAME_AS_OLD_PASSWORD("10005", "이전 비밀번호와 같은 비밀번호는 사용할 수 없습니다.", HttpStatus.CONFLICT),
 
     // 게시판 관련 오류
     POST_NOT_FOUND("20001", "해당 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailAuthPurpose.java
+++ b/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailAuthPurpose.java
@@ -1,0 +1,23 @@
+package com.freepath.devpath.email.command.application.Dto;
+
+public enum EmailAuthPurpose {
+    SIGN_UP("TEMP_USER:", "VERIFIED_USER:"),
+    FIND_LOGINID("TEMP_LOGINID:", "VERIFIED_LOGINID:"),
+    UPDATE_PASSWORD("TEMP_PASSWORD:", "VERIFIED_PASSWORD:");
+
+    private final String tempPrefix;
+    private final String verifiedPrefix;
+
+    EmailAuthPurpose(String tempPrefix, String verifiedPrefix) {
+        this.tempPrefix = tempPrefix;
+        this.verifiedPrefix = verifiedPrefix;
+    }
+
+    public String getTempKey(String email) {
+        return tempPrefix + email;
+    }
+
+    public String getVerifiedKey(String email) {
+        return verifiedPrefix + email;
+    }
+}

--- a/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailCheckDto.java
+++ b/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailCheckDto.java
@@ -1,6 +1,7 @@
 package com.freepath.devpath.email.command.application.Dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 
@@ -13,4 +14,6 @@ public class EmailCheckDto {
     @NotEmpty(message = "인증 번호를 입력해 주세요")
     private String authNum;
 
+    @NotBlank
+    private String purpose;
 }

--- a/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailRequestDto.java
+++ b/src/main/java/com/freepath/devpath/email/command/application/Dto/EmailRequestDto.java
@@ -2,6 +2,7 @@ package com.freepath.devpath.email.command.application.Dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,4 +13,7 @@ public class EmailRequestDto {
     @Email
     @NotEmpty(message = "이메일을 입력해 주세요")
     private String email;
+
+    @NotNull
+    private EmailAuthPurpose purpose;
 }

--- a/src/main/java/com/freepath/devpath/email/command/application/controller/EmailController.java
+++ b/src/main/java/com/freepath/devpath/email/command/application/controller/EmailController.java
@@ -2,6 +2,7 @@ package com.freepath.devpath.email.command.application.controller;
 
 import com.freepath.devpath.common.dto.ApiResponse;
 import com.freepath.devpath.common.exception.ErrorCode;
+import com.freepath.devpath.email.command.application.Dto.EmailAuthPurpose;
 import com.freepath.devpath.email.command.application.Dto.EmailCheckDto;
 import com.freepath.devpath.email.command.application.service.EmailService;
 import com.freepath.devpath.email.exception.EmailAuthException;
@@ -20,16 +21,20 @@ public class EmailController {
 
     private final EmailService emailService;
 
-//    @PostMapping("/email/send")
-//    public String mailSend(@RequestBody @Valid EmailRequestDto emailDto){
-//        System.out.println("이메일 인증 이메일 :"+emailDto.getEmail());
-//        return emailService.joinEmail(emailDto.getEmail());
-//    }
-
-
     @PostMapping("/email/check")
     public ResponseEntity<ApiResponse<String>> authCheck(@RequestBody @Valid EmailCheckDto emailCheckDto) {
-        boolean checked = emailService.checkAuthNum(emailCheckDto.getEmail(), emailCheckDto.getAuthNum());
+        EmailAuthPurpose purpose;
+        try {
+            purpose = EmailAuthPurpose.valueOf(emailCheckDto.getPurpose().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 인증 목적입니다: " + emailCheckDto.getPurpose());
+        }
+
+        boolean checked = emailService.checkAuthNum(
+                emailCheckDto.getEmail(),
+                emailCheckDto.getAuthNum(),
+                purpose
+        );
 
         if (checked) {
             return ResponseEntity.ok(ApiResponse.success("ok"));
@@ -37,7 +42,4 @@ public class EmailController {
             throw new EmailAuthException(ErrorCode.INVALID_EMAIL_AUTH_CODE);
         }
     }
-
-
-
 }

--- a/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
+++ b/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
@@ -32,6 +32,12 @@ public class UserCommandController {
                             ErrorCode.EMAIL_ALREADY_EXISTS.getMessage()));
         }
 
+        if (userCommandService.isLoginIdDuplicate(request.getLoginId())) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(ApiResponse.failure(ErrorCode.LOGIN_ID_ALREADY_EXISTS.getCode(),
+                            ErrorCode.LOGIN_ID_ALREADY_EXISTS.getMessage()));
+        }
+
         userCommandService.saveTempUser(request);                       // 1. 유저 정보 Redis에 임시 저장
         emailService.joinEmail(request.getEmail());                     // 2. 입력된 이메일로 인증번호 발송
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
+++ b/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
@@ -6,6 +6,7 @@ import com.freepath.devpath.email.command.application.service.EmailService;
 import com.freepath.devpath.user.command.service.UserCommandService;
 import com.freepath.devpath.user.command.dto.UserCreateRequest;
 import com.freepath.devpath.common.dto.ApiResponse;
+import com.freepath.devpath.user.command.dto.UpdatePasswordRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +52,13 @@ public class UserCommandController {
 
         Integer userId = Integer.valueOf(user.getUsername()); // 이제 username 은 userId
         userCommandService.modifyUser(request, userId);
+
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("update-password")
+    public ResponseEntity<ApiResponse<String>> findPassword(@RequestBody @Validated UpdatePasswordRequest request){
+        userCommandService.updatePassword(request.getEmail(), request.getNewPassword());
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
+++ b/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
@@ -58,7 +58,7 @@ public class UserCommandController {
 
     @PostMapping("update-password")
     public ResponseEntity<ApiResponse<String>> findPassword(@RequestBody @Validated UpdatePasswordRequest request){
-        userCommandService.updatePassword(request.getEmail(), request.getNewPassword());
+        userCommandService.updatePassword(request.getEmail(), request.getLoginId(), request.getNewPassword());
 
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/freepath/devpath/user/command/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/UpdatePasswordRequest.java
@@ -9,5 +9,6 @@ import lombok.RequiredArgsConstructor;
 public class UpdatePasswordRequest {
     @Email
     private final String email;
+    private final String loginId;
     private final String newPassword;
 }

--- a/src/main/java/com/freepath/devpath/user/command/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/UpdatePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.freepath.devpath.user.command.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdatePasswordRequest {
+    @Email
+    private final String email;
+    private final String newPassword;
+}

--- a/src/main/java/com/freepath/devpath/user/command/dto/UserCreateRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/UserCreateRequest.java
@@ -1,6 +1,5 @@
 package com.freepath.devpath.user.command.dto;
 
-import com.freepath.devpath.user.command.entity.UserRole;
 import jakarta.validation.constraints.Email;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
+++ b/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
@@ -26,4 +26,6 @@ public interface UserCommandRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.password = :password WHERE u.email = :email AND u.userDeletedAt IS NULL")
     int updatePasswordByEmail(String email, String password);
+
+    Optional<User> findByEmailAndLoginIdAndUserDeletedAtIsNull(String email, String loginId);
 }

--- a/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
+++ b/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
@@ -2,7 +2,10 @@ package com.freepath.devpath.user.command.repository;
 
 import com.freepath.devpath.user.command.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +21,9 @@ public interface UserCommandRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndUserDeletedAtIsNull(String email);
 
     boolean existsByEmailAndUserDeletedAtIsNull(String email);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE User u SET u.password = :password WHERE u.email = :email AND u.userDeletedAt IS NULL")
+    int updatePasswordByEmail(String email, String password);
 }

--- a/src/main/java/com/freepath/devpath/user/command/service/UserCommandService.java
+++ b/src/main/java/com/freepath/devpath/user/command/service/UserCommandService.java
@@ -72,6 +72,10 @@ public class UserCommandService {
         return userCommandRepository.existsByEmailAndUserDeletedAtIsNull(email);
     }
 
+    public boolean isLoginIdDuplicate(String loginId) {
+        return userCommandRepository.findByLoginId(loginId).isPresent();
+    }
+
     public void updatePassword(String email, String loginId, String newPassword) {
         // 인증 여부 확인
         String verified = redisUtil.getData("VERIFIED_PASSWORD:" + email);

--- a/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
@@ -28,7 +28,6 @@ public class UserQueryController {
                 .body(ApiResponse.success(null));
     }
 
-
     @PostMapping("/find-id")
     public ResponseEntity<ApiResponse<String>> findLoginId(@RequestBody String email){
         String loginId = userQueryService.findLoginIdByEmail(email);

--- a/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
@@ -2,8 +2,10 @@ package com.freepath.devpath.user.query.controller;
 
 import com.freepath.devpath.common.auth.service.AuthService;
 import com.freepath.devpath.common.dto.ApiResponse;
+import com.freepath.devpath.email.command.application.Dto.EmailRequestDto;
 import com.freepath.devpath.email.command.application.service.EmailService;
 import com.freepath.devpath.user.query.service.UserQueryService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +20,9 @@ public class UserQueryController {
     private final AuthService authService;
 
     @PostMapping("/verify-email")
-    public ResponseEntity<ApiResponse<Void>> findLoginIdTemp(@RequestParam String email) {
-        authService.validateUserStatusByEmail(email); // 제재 여부, 탈퇴 확인
-        emailService.sendCheckEmail(email);
+    public ResponseEntity<ApiResponse<Void>> findLoginIdTemp(@RequestBody @Valid EmailRequestDto request) {
+        authService.validateUserStatusByEmail(request.getEmail()); // 제재 여부, 탈퇴 확인
+            emailService.sendCheckEmail(request.getEmail(), request.getPurpose());
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(null));

--- a/src/main/java/com/freepath/devpath/user/query/service/UserQueryService.java
+++ b/src/main/java/com/freepath/devpath/user/query/service/UserQueryService.java
@@ -14,11 +14,8 @@ public class UserQueryService {
     private final UserMapper userMapper;
 
     public String findLoginIdByEmail(String email) {
-        System.out.println("email : " + email);
-
         // 인증 여부 확인
-        String verified = redisUtil.getData("VERIFIED_USER:" + email);
-        System.out.println("verified : " + verified);
+        String verified = redisUtil.getData("VERIFIED_LOGINID:" + email);
         if (!"true".equals(verified)) {
             throw new UserException(ErrorCode.UNAUTHORIZED_EMAIL);
         }
@@ -29,8 +26,8 @@ public class UserQueryService {
             throw new UserException(ErrorCode.USER_NOT_FOUND);
         }
 
-        redisUtil.deleteData("TEMP_USER:" + email);
-        redisUtil.deleteData("VERIFIED_USER:" + email);
+        redisUtil.deleteData("TEMP_LOGINID:" + email);
+        redisUtil.deleteData("VERIFIED_LOGINID:" + email);
 
         return loginId;
     }

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -3,6 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.freepath.devpath.user.query.mapper.UserMapper">
+    <!-- 아이디 찾기 -->
     <select id="findLoginIdByEmail" resultType="string" parameterType="string">
         SELECT login_id
         FROM users


### PR DESCRIPTION
Closes #41

## 🔥 작업 내용  
- [x] 기존의 이메일 인증 방식은 회원가입 기능에만 특화, enum을 사용해서 이메일 인증이 필요한 회원가입, 아이디 찾기, 비밀번호 재설정에서도 사용 가능하도록 변경
- [x] 인증 코드 발급 -> 이메일 인증 확인 -> 비밀번호 재설정 으로 실행하면 됨
- [x] 비밀번호 재설정 시, 회원의 이메일과 아이디 둘 다 확인한다.
- [x] 중복 회원 방지를 위해 같은 이메일, 같은 ID 는 회원가입이 불가능하다.
- [x] 비밀번호 재설정 시 이전에 사용했던 비밀번호로 바꿀 수 없다.

## ✅ 체크 리스트  
- [x] enum 으로 설정 후, 회원가입, 아이디 찾기, 비밀번호 재설정 기능 오류 없이 잘 돌아가는지.

## ✨ 관련 이슈
- #41 