### PR TITLE
feat: 일반 회원 가입 시, 아이디와 비밀번호에 제약 조건 추가

### DIFF
--- a/src/main/java/com/freepath/devpath/common/auth/dto/LoginRequest.java
+++ b/src/main/java/com/freepath/devpath/common/auth/dto/LoginRequest.java
@@ -1,11 +1,15 @@
 package com.freepath.devpath.common.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class LoginRequest {
+    @NotBlank
     private final String loginId;
+
+    @NotBlank
     private final String password;
 }

--- a/src/main/java/com/freepath/devpath/user/command/dto/ChaengePasswordRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/ChaengePasswordRequest.java
@@ -1,7 +1,6 @@
 package com.freepath.devpath.user.command.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,8 +10,12 @@ public class ChaengePasswordRequest {
 
     @Email
     private final String email;
-    @NotNull
+    @NotBlank
     private final String currentPassword;
-    @NotNull
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~])[\\w!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~]{6,12}$",
+            message = "비밀번호는 6자 이상 12자 이하이며, 특수문자를 최소 1개 포함해야 합니다"
+    )
     private final String newPassword;
 }

--- a/src/main/java/com/freepath/devpath/user/command/dto/GoogleSignUpRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/GoogleSignUpRequest.java
@@ -1,7 +1,7 @@
 package com.freepath.devpath.user.command.dto;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 public class GoogleSignUpRequest {
     @Email
     private String email;
-    @NotNull
+    @NotBlank
     private String nickname;
-    @NotNull
+    @NotBlank
     private String itNewsSubscription;
 }

--- a/src/main/java/com/freepath/devpath/user/command/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/ResetPasswordRequest.java
@@ -1,7 +1,6 @@
 package com.freepath.devpath.user.command.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,10 +8,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ResetPasswordRequest {
     @Email
-    @NotNull
+    @NotBlank
     private final String email;
-    @NotNull
+    @NotBlank
     private final String loginId;
-    @NotNull
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~])[\\w!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~]{6,12}$",
+            message = "비밀번호는 6자 이상 12자 이하이며, 특수문자를 최소 1개 포함해야 합니다"
+    )
     private final String newPassword;
 }

--- a/src/main/java/com/freepath/devpath/user/command/dto/UserCreateRequest.java
+++ b/src/main/java/com/freepath/devpath/user/command/dto/UserCreateRequest.java
@@ -1,13 +1,24 @@
 package com.freepath.devpath.user.command.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public class UserCreateRequest {
+    @NotBlank
+    @Size(max = 12)
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문 또는 숫자만 입력할 수 있습니다")
     private final String loginId;
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~])[\\w!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?`~]{6,12}$",
+            message = "비밀번호는 6자 이상 12자 이하이며, 특수문자를 최소 1개 포함해야 합니다"
+    )
     private final String password;
     @Email
     private final String email;


### PR DESCRIPTION
Closes #99 

## 🔥 작업 내용  
- [x] 아이디, 비밀번호에 제약 조건 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인

## ✨ 관련 이슈
- #99 
