### PR TITLE
feat: 탈퇴한 유저의 loginId 재사용 가능, auth와 user 컨텍스트의 컨트롤러에 @Tag, @Operation 추가

### DIFF
--- a/src/main/java/com/freepath/devpath/common/auth/controller/AuthController.java
+++ b/src/main/java/com/freepath/devpath/common/auth/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.freepath.devpath.common.auth.dto.TokenResponse;
 import com.freepath.devpath.common.auth.service.AuthService;
 import com.freepath.devpath.common.dto.ApiResponse;
 import com.freepath.devpath.common.auth.dto.UserDeleteRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,31 +15,35 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 갱신, 회원 탈퇴 등 인증 관련 기능 제공")
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "일반 로그인", description = "loginId와 password를 이용해 로그인하고 토큰을 발급받습니다")
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody LoginRequest request) {
         TokenResponse token = authService.login(request);
         return ResponseEntity.ok(ApiResponse.success(token));
     }
 
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 이용해 액세스 토큰을 재발급받습니다")
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refreshToken(@RequestBody RefreshTokenRequest request) {
         TokenResponse response = authService.refreshToken(request.getRefreshToken());
-
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "로그아웃", description = "리프레시 토큰을 만료시켜 로그아웃 처리합니다")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@RequestBody RefreshTokenRequest request) {
         authService.logout(request.getRefreshToken());
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "사용자가 자신의 계정을 탈퇴합니다. 인증 정보와 이메일 필요")
     @DeleteMapping("")
     public ResponseEntity<ApiResponse<Void>> deleteUser(
             @AuthenticationPrincipal User user,
@@ -45,7 +51,6 @@ public class AuthController {
     ) {
         String userId = user.getUsername();
         authService.deleteUser(userId, request.getEmail());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/freepath/devpath/common/auth/service/AuthService.java
+++ b/src/main/java/com/freepath/devpath/common/auth/service/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
 
 
     public TokenResponse login(LoginRequest request) {
-        User user = userCommandRepository.findByLoginId(request.getLoginId())
+        User user = userCommandRepository.findByLoginIdAndUserDeletedAtIsNull(request.getLoginId())
                 .orElseThrow(() -> new UserException(ErrorCode.INVALID_CREDENTIALS));
 
         if (!"GENERAL".equalsIgnoreCase(user.getLoginMethod())) {

--- a/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
+++ b/src/main/java/com/freepath/devpath/user/command/controller/UserCommandController.java
@@ -8,6 +8,8 @@ import com.freepath.devpath.user.command.dto.*;
 import com.freepath.devpath.email.command.application.service.EmailService;
 import com.freepath.devpath.user.command.service.UserCommandService;
 import com.freepath.devpath.common.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,15 +22,18 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "회원 관련 API", description = "회원가입, 정보 수정, 비밀번호/이메일 변경 등")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 @Slf4j
 public class UserCommandController {
+
     private final UserCommandService userCommandService;
     private final EmailService emailService;
     private final AuthService authService;
 
+    @Operation(summary = "임시 회원가입", description = "이메일 인증을 위한 임시 회원가입을 수행합니다")
     @PostMapping("/signup/temp")
     public ResponseEntity<ApiResponse<Void>> registTempUser(@RequestBody @Validated UserCreateRequest request) {
         if (userCommandService.isUserRestricted(request.getEmail())) {
@@ -52,15 +57,15 @@ public class UserCommandController {
         if(userCommandService.isNicknameDuplicate(request.getNickname())) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(ApiResponse.failure(ErrorCode.NICKNAME_ALREADY_USED.getCode(),
-                            ErrorCode.LOGIN_ID_ALREADY_EXISTS.getMessage()));
+                            ErrorCode.NICKNAME_ALREADY_USED.getMessage()));
         }
 
-        userCommandService.saveTempUser(request);                       // 1. 유저 정보 Redis에 임시 저장
-        emailService.joinEmail(request.getEmail());                     // 2. 입력된 이메일로 인증번호 발송
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(null));
+        userCommandService.saveTempUser(request);
+        emailService.joinEmail(request.getEmail());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원가입 완료", description = "이메일 인증 완료 후 실제 회원가입을 수행합니다")
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> registerUser(@RequestBody Map<String, String> body) {
         String email = body.get("email");
@@ -68,57 +73,55 @@ public class UserCommandController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
     }
 
+    @Operation(summary = "회원 정보 수정", description = "닉네임, IT 뉴스 구독 여부를 수정합니다")
     @PutMapping("/info")
     public ResponseEntity<ApiResponse<Void>> modifyUser(
             @RequestBody @Validated UserModifyRequest request,
             @AuthenticationPrincipal User user) {
 
-        Integer userId = Integer.valueOf(user.getUsername()); // 이제 username 은 userId
+        Integer userId = Integer.valueOf(user.getUsername());
         userCommandService.modifyUser(request, userId);
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "이메일 인증 요청", description = "회원가입, 이메일 변경 등을 위한 이메일 인증을 요청합니다")
     @PostMapping("/verify-email")
     public ResponseEntity<ApiResponse<Void>> findLoginIdTemp(@RequestBody @Valid EmailRequestDto request) {
         log.debug("받은 이메일: {}, 목적: {}", request.getEmail(), request.getPurpose());
 
         if (request.getPurpose() != EmailAuthPurpose.CHANGE_EMAIL) {
-            authService.validateUserStatusByEmail(request.getEmail()); // 제재 여부, 탈퇴 확인
+            authService.validateUserStatusByEmail(request.getEmail());
         }
 
         emailService.sendCheckEmail(request.getEmail(), request.getPurpose());
-
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(null));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
     }
 
-
+    @Operation(summary = "비밀번호 재설정", description = "비밀번호 찾기를 통해 비밀번호를 재설정합니다")
     @PostMapping("/reset-password")
     public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Validated ResetPasswordRequest request){
         userCommandService.resetPassword(request.getEmail(), request.getLoginId(), request.getNewPassword());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "비밀번호 변경", description = "로그인 후 비밀번호를 변경합니다")
     @PostMapping("/change-password")
     public ResponseEntity<ApiResponse<Void>> changePasword(@RequestBody @Validated ChaengePasswordRequest request){
         userCommandService.changePassword(request.getEmail(), request.getCurrentPassword(), request.getNewPassword());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "이메일 변경", description = "기존 이메일을 새 이메일로 변경합니다")
     @PostMapping("/change-email")
     public ResponseEntity<ApiResponse<Void>> changeEmail(@RequestBody @Validated ChangeEmailRequest request){
         userCommandService.changeEmail(request.getCurrentEmail(), request.getNewEmail());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "소셜 회원가입", description = "구글 로그인 이후 nickname 등 추가 정보를 받아 최종 가입을 완료합니다")
     @PostMapping("/signup-social")
     public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Validated GoogleSignUpRequest request){
         userCommandService.completeSocialSignup(request.getEmail(), request.getNickname(), request.getItNewsSubscription());
-
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
+++ b/src/main/java/com/freepath/devpath/user/command/repository/UserCommandRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserCommandRepository extends JpaRepository<User, Long> {
-    Optional<User> findByLoginId(String loginId);
 
     List<User> findByItNewsSubscription(String y);
 
@@ -43,4 +42,8 @@ public interface UserCommandRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAndUserDeletedAtIsNull(String email);
 
     boolean existsByLoginIdAndLoginMethodAndIsUserRestricted(String email, String google, String y);
+
+    boolean existsByLoginIdAndUserDeletedAtIsNull(String loginId);
+
+    Optional<User> findByLoginIdAndUserDeletedAtIsNull(String loginId);
 }

--- a/src/main/java/com/freepath/devpath/user/command/service/UserCommandService.java
+++ b/src/main/java/com/freepath/devpath/user/command/service/UserCommandService.java
@@ -88,7 +88,11 @@ public class UserCommandService {
     }
 
     public boolean isLoginIdDuplicate(String loginId) {
-        return userCommandRepository.findByLoginId(loginId).isPresent();
+        return userCommandRepository.existsByLoginIdAndUserDeletedAtIsNull(loginId);
+    }
+
+    public boolean isNicknameDuplicate(String nickname) {
+        return userCommandRepository.existsByNicknameAndUserDeletedAtIsNull(nickname);
     }
 
     public void resetPassword(String email, String loginId, String newPassword) {
@@ -190,9 +194,5 @@ public class UserCommandService {
 
         // 6. Redis에서 제거
         userRedisTemplate.delete("SOCIAL_REGISTER:" + email);
-    }
-
-    public boolean isNicknameDuplicate(String nickname) {
-        return userCommandRepository.existsByNicknameAndUserDeletedAtIsNull(nickname);
     }
 }

--- a/src/main/java/com/freepath/devpath/user/query/controller/MyPageController.java
+++ b/src/main/java/com/freepath/devpath/user/query/controller/MyPageController.java
@@ -3,6 +3,8 @@ package com.freepath.devpath.user.query.controller;
 import com.freepath.devpath.common.dto.ApiResponse;
 import com.freepath.devpath.user.query.dto.response.UserInfoResponse;
 import com.freepath.devpath.user.query.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,16 +13,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "마이페이지 API", description = "마이페이지 정보 조회")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mypage")
 public class MyPageController {
     private final MyPageService myPageService;
 
+    @Operation(summary = "내 정보 조회", description = "마이페이지에서 사용자의 기본 정보를 조회합니다")
     @GetMapping("/info")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(@AuthenticationPrincipal User user) {
         Integer userId = Integer.valueOf(user.getUsername());
-
         UserInfoResponse response = myPageService.getUserInfo(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/freepath/devpath/user/query/controller/UserQueryController.java
@@ -2,18 +2,22 @@ package com.freepath.devpath.user.query.controller;
 
 import com.freepath.devpath.common.dto.ApiResponse;
 import com.freepath.devpath.user.query.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Tag(name = "유저 조회 API", description = "유저 관련 조회 기능")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserQueryController {
     private final UserQueryService userQueryService;
 
+    @Operation(summary = "로그인 ID 찾기", description = "이메일을 통해 로그인 ID를 조회합니다")
     @PostMapping("/find-id")
     public ResponseEntity<ApiResponse<String>> findLoginId(@RequestBody Map<String, String> body){
         String email = body.get("email");


### PR DESCRIPTION
Closes #106

## 🔥 작업 내용  
- [x] 회원가입 시 loginId 사용 가능한 지 조회하는 부분에 UserDeletedAtIsNull 조건 추가
- [x] auth와 user 컨텍스트의 컨트롤러에 @Tag, @Operation 추가

## ✅ 체크 리스트  
- [ ] 기능 정상 동작 확인

## ✨ 관련 이슈
- #106 
